### PR TITLE
The page-content-wrapper had a left % indent instead of a left-padding. ...

### DIFF
--- a/habs_portal/static/css/common.css
+++ b/habs_portal/static/css/common.css
@@ -56,7 +56,7 @@ body {
 #page-content-wrapper {
     position: fixed;
     top: 140px;
-    left: 18%;
+    padding-left: 18%;
     background: teal;
     height: 100%;
     width: 100%;


### PR DESCRIPTION
... So everything inside that div was running off the page.

In the case of the map view, 18% of the map was out of the browser.  Now that the css has been fixed, @lukecampbell check out the 2 controls.

![controls](https://cloud.githubusercontent.com/assets/180985/6687541/3157ad30-cc82-11e4-9959-b65cfc7318e9.png)
