### PR TITLE
window resize model/view w/ app callback

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -95,6 +95,7 @@ module.exports = function(grunt) {
             'habs_portal/static/js/models/StationModel.js',
             'habs_portal/static/js/models/CategoryModel.js',
             'habs_portal/static/js/models/InstitutionModel.js',
+            'habs_portal/static/js/models/WindowModel.js',
             // Views
             'habs_portal/static/js/views/BannerView.js',
             'habs_portal/static/js/views/StationView.js',
@@ -107,7 +108,8 @@ module.exports = function(grunt) {
             'habs_portal/static/js/views/StationMetadataView.js',
             'habs_portal/static/js/views/SVGView.js',
             'habs_portal/static/js/views/TimeseriesView.js',
-            'habs_portal/static/js/views/PopupView.js'
+            'habs_portal/static/js/views/PopupView.js',
+            'habs_portal/static/js/views/WindowView.js'
           ],
           'habs_portal/static/js/compiled/plotting.js' : [
             // Libs
@@ -121,6 +123,7 @@ module.exports = function(grunt) {
             'habs_portal/static/js/models/StationModel.js',
             'habs_portal/static/js/models/CategoryModel.js',
             'habs_portal/static/js/models/InstitutionModel.js',
+            'habs_portal/static/js/models/WindowModel.js',
             // Views
             'habs_portal/static/js/views/BannerView.js',
             'habs_portal/static/js/views/StationView.js',
@@ -130,7 +133,8 @@ module.exports = function(grunt) {
             'habs_portal/static/js/views/TOCChildItemView.js',
             'habs_portal/static/js/views/TimeseriesView.js',
             'habs_portal/static/js/views/PlotCancelButtonsView.js',
-            'habs_portal/static/js/views/SVGView.js'
+            'habs_portal/static/js/views/SVGView.js',
+            'habs_portal/static/js/views/WindowView.js'
           ]
         }
       },

--- a/habs_portal/static/js/models/WindowModel.js
+++ b/habs_portal/static/js/models/WindowModel.js
@@ -1,0 +1,19 @@
+/*
+ * habs_portal/static/js/models/WindowModel.js
+ *
+ * Model for the window's width and height.
+ */
+
+var WindowModel = Backbone.Model.extend({
+  initialize: function() {
+    this.set_size();
+    this.listenTo(window, 'resize', _.debounce(this.set_size));
+  },
+
+  set_size: function() {
+    this.set({
+      width: $(window).width(),
+      height: $(window).height()
+    });
+  }
+});

--- a/habs_portal/static/js/views/WindowView.js
+++ b/habs_portal/static/js/views/WindowView.js
@@ -1,0 +1,16 @@
+/*
+ * habs_portal/static/js/views/WindowView.js
+ * View definition for the browser window.  This is special because it listens
+ * for model changes directly.
+ *
+ * Models:
+ *  - habs_portal/static/js/models/WindowModel.js
+ */
+var WindowView = Backbone.View.extend({
+  initialize: function() {
+    this.listenTo(this.model, 'change', this.resize);
+  },
+  resize: function() {
+    app.trigger('windowView:resize', this.model);
+  }
+});

--- a/habs_portal/templates/plotting.html
+++ b/habs_portal/templates/plotting.html
@@ -166,35 +166,35 @@ _.extend(App.prototype, Backbone.Events, {
     this.collections.stations.fetch({reset: true});
     this.collections.institutions.fetch({reset: true});
 
-    window.onload = function() {
-      _.extend(window, Backbone.Events);
-      window.onresize = function() { window.trigger('resize') };
+    /*
+      special case to listen for window resize
+    */
+    _.extend(window, Backbone.Events);
+    window.onresize = function() { window.trigger('resize') };
 
-      WindowModel = Backbone.Model.extend({
-        initialize: function() {
-          this.set_size();
-          this.listenTo(window, 'resize', _.debounce(this.set_size));
-        },
-        set_size: function() {
-          this.set({
-            width: $(window).width(),
-            height: $(window).height()
-          });
-        }
-      });
+    WindowModel = Backbone.Model.extend({
+      initialize: function() {
+        this.set_size();
+        this.listenTo(window, 'resize', _.debounce(this.set_size));
+      },
+      set_size: function() {
+        this.set({
+          width: $(window).width(),
+          height: $(window).height()
+        });
+      }
+    });
 
-      WindowView = Backbone.View.extend({
-        initialize: function() {
-          this.listenTo(this.model, 'change', this.resize);
-        },
-        resize: function() {
-          app.trigger('windowView:resize',this.model);
-        },
-      });
+    WindowView = Backbone.View.extend({
+      initialize: function() {
+        this.listenTo(this.model, 'change', this.resize);
+      },
+      resize: function() {
+        app.trigger('windowView:resize',this.model);
+      },
+    });
 
-      new WindowView({model: new WindowModel()});
-    }
-
+    new WindowView({model: new WindowModel()});
   }
 });
 

--- a/habs_portal/templates/plotting.html
+++ b/habs_portal/templates/plotting.html
@@ -157,10 +157,44 @@ _.extend(App.prototype, Backbone.Events, {
       console.log('plotCacnelButtonsView:onButtonClick: ' + options.dataset);
     });
 
+    this.listenTo(this, 'windowView:resize', function(model) {
+      console.log('Window resized to ' + model.get('width') + ' x ' + model.get('height'));
+    });
+
     /* Fetching */
     this.collections.categories.fetch({reset: true});
     this.collections.stations.fetch({reset: true});
     this.collections.institutions.fetch({reset: true});
+
+    window.onload = function() {
+      _.extend(window, Backbone.Events);
+      window.onresize = function() { window.trigger('resize') };
+
+      WindowModel = Backbone.Model.extend({
+        initialize: function() {
+          this.set_size();
+          this.listenTo(window, 'resize', _.debounce(this.set_size));
+        },
+        set_size: function() {
+          this.set({
+            width: $(window).width(),
+            height: $(window).height()
+          });
+        }
+      });
+
+      WindowView = Backbone.View.extend({
+        initialize: function() {
+          this.listenTo(this.model, 'change', this.resize);
+        },
+        resize: function() {
+          app.trigger('windowView:resize',this.model);
+        },
+      });
+
+      new WindowView({model: new WindowModel()});
+    }
+
   }
 });
 

--- a/habs_portal/templates/plotting.html
+++ b/habs_portal/templates/plotting.html
@@ -167,33 +167,11 @@ _.extend(App.prototype, Backbone.Events, {
     this.collections.institutions.fetch({reset: true});
 
     /*
-      special case to listen for window resize
+      Special case to listen for window resize.  The view is listening directly to its model
+      rather than allowing the app to broker that exchange.
     */
     _.extend(window, Backbone.Events);
     window.onresize = function() { window.trigger('resize') };
-
-    WindowModel = Backbone.Model.extend({
-      initialize: function() {
-        this.set_size();
-        this.listenTo(window, 'resize', _.debounce(this.set_size));
-      },
-      set_size: function() {
-        this.set({
-          width: $(window).width(),
-          height: $(window).height()
-        });
-      }
-    });
-
-    WindowView = Backbone.View.extend({
-      initialize: function() {
-        this.listenTo(this.model, 'change', this.resize);
-      },
-      resize: function() {
-        app.trigger('windowView:resize',this.model);
-      },
-    });
-
     new WindowView({model: new WindowModel()});
   }
 });

--- a/habs_portal/templates/stations.html
+++ b/habs_portal/templates/stations.html
@@ -186,10 +186,22 @@ _.extend(App.prototype, Backbone.Events, {
       console.log('timeseriesView:onRefreshClick: from ' + options.start + ' to ' + options.end);
     });
 
+    this.listenTo(this, 'windowView:resize', function(model) {
+      console.log('Window resized to ' + model.get('width') + ' x ' + model.get('height'));
+    });
+
     /* Fetching */
     this.collections.categories.fetch({reset: true});
     this.collections.stations.fetch({reset: true});
     this.collections.institutions.fetch({reset: true});
+
+    /*
+      Special case to listen for window resize.  The view is listening directly to its model
+      rather than allowing the app to broker that exchange.
+    */
+    _.extend(window, Backbone.Events);
+    window.onresize = function() { window.trigger('resize') };
+    new WindowView({model: new WindowModel()});
   }
 });
 


### PR DESCRIPTION
@lukecampbell This actually works, but I'm not sure how to elegantly stick it our structure.  The actual WindowView is listening to a model change as opposed to our app.

Since this window.onload is special, we can keep it self-contained like it is?

In any case, you actually get your coords back in a model.
